### PR TITLE
fix, server: fixed hibernate Activity entity relation violation

### DIFF
--- a/server/src/main/java/com/nexus/server/entities/Activity.java
+++ b/server/src/main/java/com/nexus/server/entities/Activity.java
@@ -38,10 +38,6 @@ public class Activity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id", nullable = false)
-    private Project project;
-
     /**
      * Getters and Setters ---------------------------------------------------
      */
@@ -100,13 +96,4 @@ public class Activity {
     public void setCreatedAt(LocalDate createdAt) {
         this.createdAt = createdAt;
     }
-
-    public Project getProject() {
-        return project;
-    }
-
-    public void setProject(Project project) {
-        this.project = project;
-    }
-
 }

--- a/server/src/main/java/com/nexus/server/repositories/IActivityRepository.java
+++ b/server/src/main/java/com/nexus/server/repositories/IActivityRepository.java
@@ -10,8 +10,6 @@ import java.util.List;
 public interface IActivityRepository extends JpaRepository<Activity, Long> {
     List<Activity> findByUserId(Long userId);
 
-    List<Activity> findByProjectId(Long projectId);
-
     List<Activity> findByTypeId(Long activityTypeId);
 
     /**
@@ -19,6 +17,4 @@ public interface IActivityRepository extends JpaRepository<Activity, Long> {
      */
 
     List<Activity> findAllByUserId(Long userId);
-
-    List<Activity> findAllByProjectId(Long projectId);
 }

--- a/server/src/main/resources/SQL/insert_examples.sql
+++ b/server/src/main/resources/SQL/insert_examples.sql
@@ -5,35 +5,36 @@ START TRANSACTION;
 
 -- Insertar datos de prueba para la tabla `clients`
 INSERT INTO `clients` (`id`, `name`, `email`, `address`, `phone`) VALUES
-                                                                      (1, 'John Doe', 'john@example.com', '123 Elm St, Springfield', '555-1234'),
-                                                                      (2, 'Jane Smith', 'jane@example.com', '456 Oak St, Springfield', '555-5678'),
-                                                                      (3, 'Alice Johnson', 'alice@example.com', '789 Pine St, Springfield', '555-8765');
+                                                                      (1, 'Doe John', 'doe@example.com', '123 Elm St, Springfield', '555-1234'),
+                                                                      (2, 'Smith Jane', 'smith@example.com', '456 Oak St, Springfield', '555-5678'),
+                                                                      (3, 'Johnson Alice', 'johnson@example.com', '789 Pine St, Springfield', '555-8765');
 
 -- Insertar datos de prueba para la tabla `users`
 INSERT INTO `users` (`id`, `username`, `password`, `role_id`, `dui`, `email`, `gender`, `birthday`) VALUES
-                                                                                                        (1, '$2y$06$mOc48bVddtjQCqwAOWRWGevEEkBZYtDy4DfdovU1KV0lT3G0I8ufG', 'hashed_password1', 1, 'DUI123456', 'john@example.com', 'M', '1980-01-01'),
-                                                                                                        (2, 'janesmith', '$2y$06$MxEBkz6JIdSZXYMVEBFAj.hoBnWhb8uqHM9k.CltNwz.BCy6wFumW', 2, 'DUI654321', 'jane@example.com', 'F', '1990-02-02'),
-                                                                                                        (3, 'alicej', '$2y$06$EbfilW7mUWxCVZSLHyeP/.urCcM37Lm2ph4kps/JCDE.yf3dcfcWm', 2, 'DUI789012', 'alice@example.com', 'F', '1985-03-03');
+                                                                                                        (1, 'admin', '$2y$10$aPQyBQX9cl4pKELxGdWPROF16PnF.HggKfyENsD/SZ/b8sPTDs4A2', 1, '00000000-0', 'a@dm.in', 'M', '2004-01-01'),
+                                                                                                        (2, 'johnd', '$2y$10$V7x8rAypNcRlsq8p.MjG9.zs7mxrHStfJeHG9TL/sM.jEZuLWWzUq', 2, 'DUI123456', 'john@example.com', 'M', '1980-01-01'),
+                                                                                                        (3, 'janes', '$2y$10$mpj1rrm8mKVgzZlOfKI2Ye4a7A12XBrPjpo1csWGaP98Fpd/XRi36', 3, 'DUI654321', 'jane@example.com', 'F', '1990-02-02'),
+                                                                                                        (4, 'alicej', '$2y$10$411UxKYxgGM27se3.Z3nLOUf.Sl.flGIUwMHUqXi3IxiewqN9y1Pm', 3, 'DUI789012', 'alice@example.com', 'F', '1985-03-03');
 
 -- Insertar datos de prueba para la tabla `projects`
 INSERT INTO `projects` (`id`, `client_id`, `user_id`, `title`, `description`, `status_id`, `start_date`, `end_date`, `due_date`) VALUES
-                                                                                                                                     (1, 1, 1, 'Project Alpha', 'Description of Project Alpha', 1, '2024-01-01', '2024-06-01', '2024-05-15'),
-                                                                                                                                     (2, 2, 2, 'Project Beta', 'Description of Project Beta', 2, '2024-02-01', '2024-07-01', '2024-06-15'),
-                                                                                                                                     (3, 3, 3, 'Project Gamma', 'Description of Project Gamma', 3, '2024-03-01', '2024-08-01', '2024-07-15');
+                                                                                                                                     (1, 1, 2, 'Project Alpha', 'Description of Project Alpha', 1, '2024-01-01', '2024-06-01', '2024-05-15'),
+                                                                                                                                     (2, 2, 3, 'Project Beta', 'Description of Project Beta', 2, '2024-02-01', '2024-07-01', '2024-06-15'),
+                                                                                                                                     (3, 3, 4, 'Project Gamma', 'Description of Project Gamma', 3, '2024-03-01', '2024-08-01', '2024-07-15');
 
 -- Insertar datos de prueba para la tabla `activities`
 INSERT INTO `activities` (`id`, `user_id`, `title`, `description`, `percentage`, `type_id`, `created_at`) VALUES
-                                                                                                                            (1, 1, 'Initial Design', 'Initial design phase for Project Alpha', '50%', 1, '2024-01-10'),
-                                                                                                                            (2, 2, 'Prototype Creation', 'Creating prototype for Project Alpha', '30%', 2, '2024-02-15'),
-                                                                                                                            (3, 1, 'Market Research', 'Conducting market research for Project Beta', '70%', 1, '2024-03-20'),
-                                                                                                                            (4, 3, 'Quality Assurance', 'Quality checks for Project Gamma', '20%', 4, '2024-04-25');
+                                                                                                              (1, 2, 'Initial Design', 'Initial design phase for Project Alpha', '50%', 1, '2024-01-10'),
+                                                                                                              (2, 3, 'Prototype Creation', 'Creating prototype for Project Alpha', '30%', 2, '2024-02-15'),
+                                                                                                              (3, 3, 'Market Research', 'Conducting market research for Project Beta', '70%', 1, '2024-03-20'),
+                                                                                                              (4, 4, 'Quality Assurance', 'Quality checks for Project Gamma', '20%', 4, '2024-04-25');
 
 -- Insertar datos de prueba para la tabla `logs`
-INSERT INTO `logs` (`id`, `project_id`, `activity_id`, `date`, `description`) VALUES
-                                                                                  (1, 1, 1),
-                                                                                  (2, 1, 2),
-                                                                                  (3, 2, 3),
-                                                                                  (4, 3, 4);
+INSERT INTO `logs` (`id`, `project_id`, `activity_id`) VALUES
+                                                           (1, 1, 1),
+                                                           (2, 1, 2),
+                                                           (3, 2, 3),
+                                                           (4, 3, 4);
 
 -- Confirmar la transacción
 COMMIT;

--- a/server/src/main/resources/SQL/nexus_workshop.sql
+++ b/server/src/main/resources/SQL/nexus_workshop.sql
@@ -86,8 +86,8 @@ CREATE TABLE `logs` (
                         `id` bigint NOT NULL,
                         `project_id` bigint DEFAULT NULL,
                         `activity_id` bigint DEFAULT NULL
-#                         ,`date` date NOT NULL,
-#                         `description` varchar(255) DEFAULT NULL
+                            #                         ,`date` date NOT NULL,
+                        #                         `description` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- --------------------------------------------------------
@@ -147,8 +147,9 @@ CREATE TABLE `roles` (
 --
 
 INSERT INTO `roles` (`id`, `name`) VALUES
-                                       (1, 'admin'),
-                                       (2, 'employee');
+                                       (1, 'ADMIN'),
+                                       (2, 'BOSS'),
+                                       (3, 'EMPLOYEE');
 
 -- --------------------------------------------------------
 


### PR DESCRIPTION
This pull request includes several changes across multiple files to remove the `Project` association from the `Activity` entity and update the SQL insert statements for consistency and clarity. The most important changes include removing the `Project` field from the `Activity` entity, updating the repository interfaces, and modifying SQL insert statements.

### Removal of `Project` association from `Activity` entity:

* [`server/src/main/java/com/nexus/server/entities/Activity.java`](diffhunk://#diff-50e96461b293327b3b36a8e1ad1020d5be6a9bbd2a7e254a486b90420a38db17L41-L44): Removed the `Project` field and its associated getter and setter methods from the `Activity` entity. [[1]](diffhunk://#diff-50e96461b293327b3b36a8e1ad1020d5be6a9bbd2a7e254a486b90420a38db17L41-L44) [[2]](diffhunk://#diff-50e96461b293327b3b36a8e1ad1020d5be6a9bbd2a7e254a486b90420a38db17L103-L111)
* [`server/src/main/java/com/nexus/server/repositories/IActivityRepository.java`](diffhunk://#diff-e7112005cbe467331049633d236e1b9ec6cf47b73b8a76d92767d8cdeb91f523L13-L23): Removed methods related to finding activities by `ProjectId`.

### Updates to SQL insert statements:

* [`server/src/main/resources/SQL/insert_examples.sql`](diffhunk://#diff-3c1be4f1531b0ea0bfa665ff8fe60d1e0539a32d021d2a48560a9edb234abc98L8-R33): Updated insert statements for `clients`, `users`, `projects`, and `activities` tables to reflect changes in user and project associations.
* [`server/src/main/resources/SQL/nexus_workshop.sql`](diffhunk://#diff-2aac0d532d4d376f27d3d7831ba4416d348a7af48407c90e0233fd2bcd5ba604L150-R152): Modified the `roles` table insert statements to use uppercase role names and added a new role.