### PR TITLE
fixing textarea floatPlaceholder bug

### DIFF
--- a/client/src/main/resources/static/js/floatPlaceholder.js
+++ b/client/src/main/resources/static/js/floatPlaceholder.js
@@ -1,13 +1,13 @@
 $(document).ready(function () {
-    // Add class 'has-value' if the input had value after loading
-    $('.form-input input').each(function () {
+    // Add class 'has-value' if the input or textarea had value after loading
+    $('.form-input input, .form-input textarea').each(function () {
         if ($(this).val().length > 0) {
             $(this).parent().addClass('has-value');
         }
     });
 
     // Listen on inputs to add or remove the class 'has-value'
-    $('.form-input input').on('focus input', function () {
+    $('.form-input input, .form-input textarea').on('focus input', function () {
         if ($(this).val().length > 0){
             $(this).parent().addClass('has-value');
         } else {


### PR DESCRIPTION
This pull request includes a small but important change to the `floatPlaceholder.js` file. The change ensures that textareas are also considered when adding or removing the `has-value` class.

* [`client/src/main/resources/static/js/floatPlaceholder.js`](diffhunk://#diff-6a8904eabd6693dda8a9a6c996bb2ad5ff43801bdbc86dbfb71b1756aa5838caL2-R10): Modified the script to include textareas in addition to inputs when checking for and toggling the `has-value` class.